### PR TITLE
修改树状控件一个界面存在多个时，只有一个树状控件的子控件响应事件

### DIFF
--- a/nim_win_demo/gui/extern_ctrl/treectrl/treeview.cpp
+++ b/nim_win_demo/gui/extern_ctrl/treectrl/treeview.cpp
@@ -125,7 +125,11 @@ ui::Control* TreeComponent::FindControlFromPoint(const ui::CPoint& pt)
 		ui::UiRect pos = pThis->GetPos();
 		return ::PtInRect(&pos, *pPoint) ? pThis : NULL;
 		}, &pt_temp, UIFIND_VISIBLE | UIFIND_HITTEST | UIFIND_TOP_FIRST);
-	if (ret == this && IsVisible())
+	if (ret != this)
+	{
+		return NULL;
+	}
+	if (IsVisible())
 	{
 		for (auto& it : visible_item_list_)
 		{


### PR DESCRIPTION
一个窗口中存在多个树状节点，只有一个树状节点能响应事件，因为多次调用AddControlFromPointFinder，导致FindControl时只有null，才会循环判断，但如果存在多个时，会返回第一个树状节点，导致其他树状节点不会遍历子控件